### PR TITLE
Fix: Don't include README text directly into documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,11 @@ C3S MAGIC WPS
 .. image:: https://zenodo.org/badge/184254565.svg
    :target: https://zenodo.org/badge/latestdoi/184254565
 
+.. inclusion-marker-start-do-not-remove
+
 Web Processing Service for Climate Data Analysis in the MAGIC project. The software in this WPS powers the processes behind the C3S-MAGIC portal. The processes are run on CP4CDS infrastructure.
+
+.. inclusion-marker-end-do-not-remove
 
 * Free software: Apache Software License 2.0
 * Documentation: https://c3s-magic-wps.readthedocs.io.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,9 @@
 C3S MAGIC WPS
 =============
 
-Web Processing Service for Climate Data Analysis in
-the MAGIC project. The software in this WPS powers
-the processes behind the C3S-MAGIC portal. The processes
-can be run on any compute resource with access to CP4CDS
-CMIP data, and are typically run on CP4CDS infrastructure.
+.. include:: ../../README.rst
+  :start-after: inclusion-marker-start-do-not-remove
+  :end-before: inclusion-marker-end-do-not-remove
 
 .. toctree::
    :maxdepth: 1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,5 @@ pytest-flake8
 sphinx>=1.7
 sphinx-autoapi
 -e git+https://github.com/huard/sphinx-autodoc-pywps.git#egg=sphinx_autodoc_pywps
+sphinx_rtd_theme
 bumpversion


### PR DESCRIPTION
This PR uses the relevant text in  the README directly in the sphinx documentation by using inclusion markers.
